### PR TITLE
do not choke on valid arguments

### DIFF
--- a/src/main/java/de/nsvb/monkeyremote/MonkeyRemote.java
+++ b/src/main/java/de/nsvb/monkeyremote/MonkeyRemote.java
@@ -81,6 +81,7 @@ public class MonkeyRemote extends JFrame {
         if(args.length == 2){
             adb = args[0];
             scalingFactor = Float.parseFloat(args[1]);
+            args = new String[0];
         } 
         if (args.length > 0 || !new File(adb).exists() || new File(adb).isDirectory()){
             if(!new File(adb).exists()){


### PR DESCRIPTION
Even with correct arguments, (args.length>0) is true and leads to
System.out.println("Usage: MonkeyRemote [Path to ADB executable] [Scaling factor]");
Otherways: really useful project, thanks!